### PR TITLE
Fix return value of tree

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -52,7 +52,7 @@ declare class Undertaker {
      * Optionally takes an object (options) and returns an object representing the tree of registered tasks.
      * @param options
      */
-    tree(options?: { deep?: boolean }): Node[] | string[];
+    tree(options?: { deep?: boolean }): Undertaker.Node[] | string[];
 
     /**
      * Takes a string or function (task) and returns a timestamp of the last time the task was run successfully.


### PR DESCRIPTION
Hi,
The current return value of `tree` does not use the `Node` interface defined in the `Undertaker` interface but the one from the `dom.d.ts` TS lib.
I fixed it by specifying the namespace.

(I found this error when compiling without the standard lib)